### PR TITLE
Support multiple Elfsquad configurator model IDs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,9 @@
 ElfsquadClientId=your_elfsquad_client_id
 ElfsquadClientSecret=your_elfsquad_client_secret
-# Maps Elfsquad configurator model IDs to the DynaMaker application that renders them.
-# Format: <modelId>:<dynamakerApplicationId>, comma-separated, no spaces. Several model IDs
-# may map to the same application.
-ElfsquadModelToDynamakerApplicationMap=your_elfsquad_config_model_id:your_dynamaker_application_id
+# Maps each DynaMaker application to the Elfsquad configurator model IDs it renders.
+# Format: <applicationId>:<modelId>,<modelId>;<applicationId>:<modelId> — entries separated by
+# semicolons, model IDs by commas, no spaces. An application may list several model IDs.
+DynamakerApplicationToElfsquadModelsMap=your_dynamaker_application_id:your_elfsquad_config_model_id
 
 QfsApiKey=your_qfs_api_key
 QfsEnvironment=test

--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 ElfsquadClientId=your_elfsquad_client_id
 ElfsquadClientSecret=your_elfsquad_client_secret
-ElfsquadConfiguratorModelId=your_elfsquad_config_model_id
+# Comma-separated list of Elfsquad configurator model IDs (no spaces around commas)
+ElfsquadConfiguratorModelIds=your_elfsquad_config_model_id
 
 DynamakerApplicationId=your_dynamaker_application_id
 QfsApiKey=your_qfs_api_key

--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,10 @@
 ElfsquadClientId=your_elfsquad_client_id
 ElfsquadClientSecret=your_elfsquad_client_secret
-# Comma-separated list of Elfsquad configurator model IDs (no spaces around commas)
-ElfsquadConfiguratorModelIds=your_elfsquad_config_model_id
+# Maps Elfsquad configurator model IDs to the DynaMaker application that renders them.
+# Format: <modelId>:<dynamakerApplicationId>, comma-separated, no spaces. Several model IDs
+# may map to the same application.
+ElfsquadModelToDynamakerApplicationMap=your_elfsquad_config_model_id:your_dynamaker_application_id
 
-DynamakerApplicationId=your_dynamaker_application_id
 QfsApiKey=your_qfs_api_key
 QfsEnvironment=test
 QfsTaskName=generate-pdf

--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ You can trigger the DynaMaker job from Elfsquad in two ways: using webhooks or c
 ## Environment Variables
 Configure all required variables in your `.env.production` file. Refer to `.env.example` for details and example values.
 
+`ElfsquadConfiguratorModelIds` accepts a comma-separated list of Elfsquad configurator model IDs (without spaces around
+the commas). Only configurations belonging to one of these models are sent to QFS; all others are skipped.
+
 ## Deployment
 Deploy the application using `npm run deploy`.
 

--- a/README.md
+++ b/README.md
@@ -52,10 +52,10 @@ You can trigger the DynaMaker job from Elfsquad in two ways: using webhooks or c
 ## Environment Variables
 Configure all required variables in your `.env.production` file. Refer to `.env.example` for details and example values.
 
-`ElfsquadModelToDynamakerApplicationMap` maps each supported Elfsquad configurator model ID to the DynaMaker
-application that renders it, as a comma-separated list of `<modelId>:<applicationId>` pairs (without spaces). Several
-model IDs may map to the same application. Only configurations belonging to one of the listed models are sent to QFS
-(using the mapped application ID); all others are skipped.
+`DynamakerApplicationToElfsquadModelsMap` maps each DynaMaker application to the Elfsquad configurator model IDs it
+renders, as a semicolon-separated list of `<applicationId>:<modelId>,<modelId>` entries (without spaces). An
+application may list several comma-separated model IDs. Only configurations belonging to one of the listed models are
+sent to QFS (using the application ID they are listed under); all others are skipped.
 
 ## Deployment
 Deploy the application using `npm run deploy`.

--- a/README.md
+++ b/README.md
@@ -52,8 +52,10 @@ You can trigger the DynaMaker job from Elfsquad in two ways: using webhooks or c
 ## Environment Variables
 Configure all required variables in your `.env.production` file. Refer to `.env.example` for details and example values.
 
-`ElfsquadConfiguratorModelIds` accepts a comma-separated list of Elfsquad configurator model IDs (without spaces around
-the commas). Only configurations belonging to one of these models are sent to QFS; all others are skipped.
+`ElfsquadModelToDynamakerApplicationMap` maps each supported Elfsquad configurator model ID to the DynaMaker
+application that renders it, as a comma-separated list of `<modelId>:<applicationId>` pairs (without spaces). Several
+model IDs may map to the same application. Only configurations belonging to one of the listed models are sent to QFS
+(using the mapped application ID); all others are skipped.
 
 ## Deployment
 Deploy the application using `npm run deploy`.

--- a/src/qfs-task-trigger.js
+++ b/src/qfs-task-trigger.js
@@ -3,10 +3,15 @@ import axios from "axios";
 
 const QFS_API_JOBS_ENDPOINT = "https://qfs.dynamaker.com/jobs";
 const QFS_TASK_NAME = process.env.QfsTaskName || "generate-pdf";
-const ELFSQUAD_CONFIGURATOR_MODEL_IDS = (process.env.ElfsquadConfiguratorModelIds || "")
-  .split(",")
-  .map(id => id.trim())
-  .filter(Boolean);
+// Maps each supported Elfsquad configurator model ID to the DynaMaker application that renders it.
+// Format: <configuratorModelId>:<dynamakerApplicationId>, comma-separated. Several model IDs may
+// map to the same application.
+const MODEL_ID_TO_APPLICATION_ID = new Map(
+  (process.env.ElfsquadModelToDynamakerApplicationMap || "")
+    .split(",")
+    .map(pair => pair.split(":").map(part => part.trim()))
+    .filter(([modelId, applicationId]) => modelId && applicationId)
+);
 const ELFSQUAD_WEBHOOK_TOPIC_QUOTATION_CONFIGURATION_ADDED = 'quotation.configurationadded';
 const ELFSQUAD_WEBHOOK_TOPIC_QUOTATION_REVISION_MADE = 'quotation.revisionmade';
 const ELFSQUAD_WEBHOOK_TOPIC_QUOTATION_COPIED = 'quotation.copied';
@@ -128,10 +133,11 @@ async function getConfigurationIdsFromQuotation(elfsquadApi, quotationId) {
 async function triggerQfsJobForConfiguration(elfsquadApi, quotationId, configurationId) {
   const configuration = await getConfigurationData(elfsquadApi, configurationId);
 
-  // Check configuration model ID
-  if (!ELFSQUAD_CONFIGURATOR_MODEL_IDS.includes(configuration.configurationModelId)) {
+  // Look up the DynaMaker application responsible for this configuration's model ID
+  const applicationId = MODEL_ID_TO_APPLICATION_ID.get(configuration.configurationModelId);
+  if (!applicationId) {
     console.log(`Configuration ${configurationId} with model ID ${configuration.configurationModelId} is not in the` +
-      ` list of supported model IDs (${ELFSQUAD_CONFIGURATOR_MODEL_IDS.join(", ") || "none configured"}). Skipping.`);
+      ` list of supported model IDs (${[...MODEL_ID_TO_APPLICATION_ID.keys()].join(", ") || "none configured"}). Skipping.`);
     return {
       statusCode: 200,
       message: "Model ID not supported. Skipped."
@@ -143,7 +149,7 @@ async function triggerQfsJobForConfiguration(elfsquadApi, quotationId, configura
 
   // Start QFS job
   const qfsRes = await axios.post(QFS_API_JOBS_ENDPOINT, {
-    applicationId: process.env.DynamakerApplicationId,
+    applicationId,
     task: QFS_TASK_NAME,
     environment: process.env.QfsEnvironment,
     configuration,

--- a/src/qfs-task-trigger.js
+++ b/src/qfs-task-trigger.js
@@ -3,6 +3,10 @@ import axios from "axios";
 
 const QFS_API_JOBS_ENDPOINT = "https://qfs.dynamaker.com/jobs";
 const QFS_TASK_NAME = process.env.QfsTaskName || "generate-pdf";
+const ELFSQUAD_CONFIGURATOR_MODEL_IDS = (process.env.ElfsquadConfiguratorModelIds || "")
+  .split(",")
+  .map(id => id.trim())
+  .filter(Boolean);
 const ELFSQUAD_WEBHOOK_TOPIC_QUOTATION_CONFIGURATION_ADDED = 'quotation.configurationadded';
 const ELFSQUAD_WEBHOOK_TOPIC_QUOTATION_REVISION_MADE = 'quotation.revisionmade';
 const ELFSQUAD_WEBHOOK_TOPIC_QUOTATION_COPIED = 'quotation.copied';
@@ -125,12 +129,12 @@ async function triggerQfsJobForConfiguration(elfsquadApi, quotationId, configura
   const configuration = await getConfigurationData(elfsquadApi, configurationId);
 
   // Check configuration model ID
-  if (configuration.configurationModelId !== process.env.ElfsquadConfiguratorModelId) {
-    console.log(`Configuration ${configurationId} with model ID ${configuration.configurationModelId} does not match` +
-      ` expected ${process.env.ElfsquadConfiguratorModelId}. Skipping.`);
+  if (!ELFSQUAD_CONFIGURATOR_MODEL_IDS.includes(configuration.configurationModelId)) {
+    console.log(`Configuration ${configurationId} with model ID ${configuration.configurationModelId} is not in the` +
+      ` list of supported model IDs (${ELFSQUAD_CONFIGURATOR_MODEL_IDS.join(", ") || "none configured"}). Skipping.`);
     return {
       statusCode: 200,
-      message: "Model ID does not match. Skipped."
+      message: "Model ID not supported. Skipped."
     };
   }
 

--- a/src/qfs-task-trigger.js
+++ b/src/qfs-task-trigger.js
@@ -4,13 +4,18 @@ import axios from "axios";
 const QFS_API_JOBS_ENDPOINT = "https://qfs.dynamaker.com/jobs";
 const QFS_TASK_NAME = process.env.QfsTaskName || "generate-pdf";
 // Maps each supported Elfsquad configurator model ID to the DynaMaker application that renders it.
-// Format: <configuratorModelId>:<dynamakerApplicationId>, comma-separated. Several model IDs may
-// map to the same application.
+// Configured per application: <dynamakerApplicationId>:<modelId>,<modelId>, entries separated by
+// semicolons. An application may list several model IDs.
 const MODEL_ID_TO_APPLICATION_ID = new Map(
-  (process.env.ElfsquadModelToDynamakerApplicationMap || "")
-    .split(",")
-    .map(pair => pair.split(":").map(part => part.trim()))
-    .filter(([modelId, applicationId]) => modelId && applicationId)
+  (process.env.DynamakerApplicationToElfsquadModelsMap || "")
+    .split(";")
+    .map(entry => entry.split(":").map(part => part.trim()))
+    .filter(([applicationId, modelIds]) => applicationId && modelIds)
+    .flatMap(([applicationId, modelIds]) => modelIds
+      .split(",")
+      .map(modelId => modelId.trim())
+      .filter(Boolean)
+      .map(modelId => [modelId, applicationId]))
 );
 const ELFSQUAD_WEBHOOK_TOPIC_QUOTATION_CONFIGURATION_ADDED = 'quotation.configurationadded';
 const ELFSQUAD_WEBHOOK_TOPIC_QUOTATION_REVISION_MADE = 'quotation.revisionmade';

--- a/template.yaml
+++ b/template.yaml
@@ -7,7 +7,7 @@ Parameters:
     Type: String
   ElfsquadClientSecret:
     Type: String
-  ElfsquadModelToDynamakerApplicationMap:
+  DynamakerApplicationToElfsquadModelsMap:
     Type: String
   QfsApiKey:
     Type: String
@@ -31,7 +31,7 @@ Resources:
         Variables:
           ElfsquadClientId: !Ref ElfsquadClientId
           ElfsquadClientSecret: !Ref ElfsquadClientSecret
-          ElfsquadModelToDynamakerApplicationMap: !Ref ElfsquadModelToDynamakerApplicationMap
+          DynamakerApplicationToElfsquadModelsMap: !Ref DynamakerApplicationToElfsquadModelsMap
           QfsApiKey: !Ref QfsApiKey
           QfsCallbackFunctionUrl: !GetAtt QFSCallbackFunctionUrl.FunctionUrl
           QfsEnvironment: !Ref QfsEnvironment

--- a/template.yaml
+++ b/template.yaml
@@ -7,7 +7,7 @@ Parameters:
     Type: String
   ElfsquadClientSecret:
     Type: String
-  ElfsquadConfiguratorModelId:
+  ElfsquadConfiguratorModelIds:
     Type: String
   DynamakerApplicationId:
     Type: String
@@ -34,7 +34,7 @@ Resources:
           DynamakerApplicationId: !Ref DynamakerApplicationId
           ElfsquadClientId: !Ref ElfsquadClientId
           ElfsquadClientSecret: !Ref ElfsquadClientSecret
-          ElfsquadConfiguratorModelId: !Ref ElfsquadConfiguratorModelId
+          ElfsquadConfiguratorModelIds: !Ref ElfsquadConfiguratorModelIds
           QfsApiKey: !Ref QfsApiKey
           QfsCallbackFunctionUrl: !GetAtt QFSCallbackFunctionUrl.FunctionUrl
           QfsEnvironment: !Ref QfsEnvironment

--- a/template.yaml
+++ b/template.yaml
@@ -7,9 +7,7 @@ Parameters:
     Type: String
   ElfsquadClientSecret:
     Type: String
-  ElfsquadConfiguratorModelIds:
-    Type: String
-  DynamakerApplicationId:
+  ElfsquadModelToDynamakerApplicationMap:
     Type: String
   QfsApiKey:
     Type: String
@@ -31,10 +29,9 @@ Resources:
       Handler: qfs-task-trigger.handler
       Environment:
         Variables:
-          DynamakerApplicationId: !Ref DynamakerApplicationId
           ElfsquadClientId: !Ref ElfsquadClientId
           ElfsquadClientSecret: !Ref ElfsquadClientSecret
-          ElfsquadConfiguratorModelIds: !Ref ElfsquadConfiguratorModelIds
+          ElfsquadModelToDynamakerApplicationMap: !Ref ElfsquadModelToDynamakerApplicationMap
           QfsApiKey: !Ref QfsApiKey
           QfsCallbackFunctionUrl: !GetAtt QFSCallbackFunctionUrl.FunctionUrl
           QfsEnvironment: !Ref QfsEnvironment


### PR DESCRIPTION
Rename the ElfsquadConfiguratorModelId parameter to ElfsquadConfiguratorModelIds, which now accepts a comma-separated list of model IDs. Configurations are sent to QFS if their model ID matches any entry in the list; all others are skipped as before.