### PR TITLE
Read QFS failure message from callback body and log it to the quotation

### DIFF
--- a/src/qfs-callback.js
+++ b/src/qfs-callback.js
@@ -7,17 +7,26 @@ const ELFSQUAD_API_BASE_URL = "https://api.elfsquad.io";
 
 export const handler = async (event) => {
   const queryParams = event.queryStringParameters;
+  const configurationId = queryParams?.cid;
+  const quotationId = queryParams?.qid;
 
   if (queryParams?.success === 'false') {
-    console.error('QFS job failed:', queryParams.message);
+    const message = getFailureMessage(event);
+    console.error('QFS job failed:', message);
+    if (quotationId) {
+      try {
+        const elfsquadApi = await getElfsquadApi();
+        await addQuotationLog(elfsquadApi, quotationId, `QFS job failed for configuration ${configurationId}: ${message}`);
+      } catch (error) {
+        console.error('Failed to write failure message to quotation log:', error);
+      }
+    }
     return {
       statusCode: 400,
-      body: JSON.stringify({ message: 'QFS job failed', details: queryParams.message })
+      body: JSON.stringify({ message: 'QFS job failed', details: message })
     };
   }
 
-  const configurationId = queryParams?.cid;
-  const quotationId = queryParams?.qid;
   if (!configurationId || !quotationId) {
     console.error('Missing configurationId and/or quotationId in query parameters.');
     return {
@@ -63,5 +72,20 @@ export const handler = async (event) => {
       statusCode: 500,
       body: JSON.stringify({ message: 'Upload failed', error: error?.message || error })
     };
+  }
+}
+
+/**
+ * Extract the failure message from the callback request. On failure, QFS sends a JSON body
+ * containing a message property (not a query parameter).
+ * @param event
+ */
+function getFailureMessage(event) {
+  const rawBody = event.isBase64Encoded ? Buffer.from(event.body ?? '', 'base64').toString('utf8') : event.body;
+  try {
+    const body = typeof rawBody === 'string' ? JSON.parse(rawBody) : rawBody;
+    return body?.message ?? 'No failure message provided.';
+  } catch {
+    return rawBody || 'No failure message provided.';
   }
 }


### PR DESCRIPTION
On a failed job, QFS sends success=false as a query parameter but the error message as a JSON body property, not as a query parameter. The handler previously logged queryParams.message, which is always undefined, so the actual failure reason was lost.

Parse the message from the (possibly base64-encoded) body instead, and also write it to the quotation developer log so it is visible in Elfsquad.